### PR TITLE
Remediate missing Count property in Get-MgDeviceManagementManagedDevice

### DIFF
--- a/Intune-Set-PrimaryUsers.ps1
+++ b/Intune-Set-PrimaryUsers.ps1
@@ -249,7 +249,7 @@ function Set-IntunePrimaryUsers {
             $i++
             #Get current Primary User
             if ($AllPrimaryUsersHash.count -gt 0){$PrimaryuserHash = $AllPrimaryUsersHash[$IntuneDevice.id]
-                $primaryUserJson = ($primaryuserHash.body.value | ConvertTo-Json -Depth 9 | ConvertFrom-Json -Depth 9)
+                $primaryUserJson = ($primaryuserHash.body.value | ConvertTo-Json -Depth 9 | ConvertFrom-Json)
                 if ($primaryUserJson -and $primaryUserJson.PSObject.Properties.Name -contains 'userprincipalname') {
                     $primaryuser = $primaryUserJson.userprincipalname}
                 write-verbose "$(Get-Date -Format 'yyyy-MM-dd'),$(Get-Date -format 'HH:mm:ss'),Success to get Primary User $($Primaryuser) for $($IntuneDevice.DeviceName) from batch lookup"}
@@ -314,7 +314,7 @@ $StartTime = Get-Date
 $MgGraphAccessToken = ConnectTo-MgGraph -RequiredScopes $RequiredScopes
 
 #Get Intune Devices
-try{$IntuneDevices = Get-MgDeviceManagementManagedDevice -filter "operatingSystem eq 'Windows'and LastSyncDateTime gt $($DeviceStartTime.ToString("yyyy-MM-ddTHH:mm:ssZ"))" -all -Property "AzureAdDeviceId,DeviceName,Id"
+try{$IntuneDevices =@(Get-MgDeviceManagementManagedDevice -filter "operatingSystem eq 'Windows'and LastSyncDateTime gt $($DeviceStartTime.ToString("yyyy-MM-ddTHH:mm:ssZ"))" -all -Property "AzureAdDeviceId,DeviceName,Id")
     write-verbose "$(Get-Date -Format 'yyyy-MM-dd'),$(Get-Date -format 'HH:mm:ss'),Success to get $($IntuneDevices.count) Devices with selected properties for devices synced last $($DeviceTimeSpan) days"}
 catch{write-Error "$(Get-Date -Format 'yyyy-MM-dd'),$(Get-Date -format 'HH:mm:ss'),Failed to get Devices with error: $_"}
 

--- a/Intune-Set-PrimaryUsers.ps1
+++ b/Intune-Set-PrimaryUsers.ps1
@@ -314,7 +314,7 @@ $StartTime = Get-Date
 $MgGraphAccessToken = ConnectTo-MgGraph -RequiredScopes $RequiredScopes
 
 #Get Intune Devices
-try{$IntuneDevices =@(Get-MgDeviceManagementManagedDevice -filter "operatingSystem eq 'Windows'and LastSyncDateTime gt $($DeviceStartTime.ToString("yyyy-MM-ddTHH:mm:ssZ"))" -all -Property "AzureAdDeviceId,DeviceName,Id")
+try{$IntuneDevices = @(Get-MgDeviceManagementManagedDevice -filter "operatingSystem eq 'Windows'and LastSyncDateTime gt $($DeviceStartTime.ToString("yyyy-MM-ddTHH:mm:ssZ"))" -all -Property "AzureAdDeviceId,DeviceName,Id")
     write-verbose "$(Get-Date -Format 'yyyy-MM-dd'),$(Get-Date -format 'HH:mm:ss'),Success to get $($IntuneDevices.count) Devices with selected properties for devices synced last $($DeviceTimeSpan) days"}
 catch{write-Error "$(Get-Date -Format 'yyyy-MM-dd'),$(Get-Date -format 'HH:mm:ss'),Failed to get Devices with error: $_"}
 


### PR DESCRIPTION
1. Line 352: As suggested by @B1mbojr1, ConvertFrom-Json will not recognize the parameter -Depth 9, hence removed it.
2. Line 317: This was mind-boggling, not sure who removed the 'Count' property from "Get-MgDeviceManagementManagedDevice", tried different ways included 'adding | measure in a different variable', the most seamless way to resolve this would be to save the $IntuneDevices as an array so the 'Count' property would be recognized in the rest of the script, otherwise the batch mode and success message with $Intunedevices.count fails.